### PR TITLE
Pas exporter les cibles historiques 

### DIFF
--- a/01_entrepot/scripts/utilisation_intrant_cible.sql
+++ b/01_entrepot/scripts/utilisation_intrant_cible.sql
@@ -28,4 +28,5 @@ select
 	ppt.target as ref_cible_id,
 	ppt.category as categorie, 
 	ppt.codegroupeciblemaa as code_groupe_cible_maa
-	from phytoproducttarget ppt;
+	from phytoproducttarget ppt
+	where ppt.abstractphytoproductinputusage is not null;


### PR DESCRIPTION
Modification de l'entrepôt : 
- certaines cibles de la table phytoproducttarget n'ont pas d'utilisation d'intrant liés. Il s'agit d'ancienne cibles qui n'ont pas pu être migrées. On les retire donc de l'entrepôt puisqu'elles ne sont plus exploitables.